### PR TITLE
Reformat version number

### DIFF
--- a/Audacia.Locality/Audacia.Locality.csproj
+++ b/Audacia.Locality/Audacia.Locality.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard1.2;netstandard2.0</TargetFrameworks>
-    <Version>1.1.0.0</Version>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <Version>1.2.0.0</Version>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
     <Description>Geographical Country Data  in a strongly-typed format.</Description>
     <Copyright>Copyright © Audacia 2017</Copyright>
     <PackageIconUrl>https://www.audacia.co.uk/media/pkenoobu/audacia-logo-circle-blue.png</PackageIconUrl>

--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-name: $(Build.BuildId).$(Year:yy)$(DayOfYear)
+name: $(Year:yy)$(DayOfYear).$(rev:r)
 trigger: [master]
 pr: { branches: { include: [master] } }
 schedules: [ { cron: "0 0 * * *", displayName: Nightly Build, branches: { include: [ master ] } } ]


### PR DESCRIPTION
Changing the build version number format from `$(Build.BuildId).$(Year:yy)$(DayOfYear)` to `$(Year:yy)$(DayOfYear).$(rev:r)` to avoid datatype capacity limitations.
Incrementing the version number to `1.2` to ensure new builds are the highest version number.